### PR TITLE
fix `IndexError: index out of range`

### DIFF
--- a/io_import_z64.py
+++ b/io_import_z64.py
@@ -826,7 +826,7 @@ class F3DZEX:
     def locateHierarchies(self):
         log = getLogger('F3DZEX.locateHierarchies')
         data = self.segment[0x06]
-        for i in range(0, len(data), 4):
+        for i in range(0, len(data) - 4, 4):
             # test for header "bboooooo pp000000 xx000000": if segment bb=0x06 and offset oooooo 4-aligned and not zero parts (pp!=0)
             if data[i] == 0x06 and (data[i+3] & 3) == 0 and data[i+4] != 0:
                 offset = unpack_from(">L", data, i)[0] & 0x00FFFFFF
@@ -855,7 +855,7 @@ class F3DZEX:
         self.animation = []
         self.offsetAnims = []
         self.durationAnims = []
-        for i in range(0, len(data), 4):
+        for i in range(0, len(data) - 4, 4):
             if ((data[i] == 0) and (data[i+1] > 1) and
                  (data[i+2] == 0) and (data[i+3] == 0) and
                  (data[i+4] == 0x06) and
@@ -877,7 +877,7 @@ class F3DZEX:
         data = self.segment[0x0F]
         self.animation = []
         self.offsetAnims = []
-        for i in range(0, len(data), 4):
+        for i in range(0, len(data) - 4, 4):
             if ((data[i] == 0) and (data[i+1] > 1) and
                  (data[i+2] == 0) and (data[i+3] == 0) and
                  (data[i+4] == 0x06) and


### PR DESCRIPTION
This file ([zelda_ironknack.zip](https://github.com/Dragorn421/zelda64-import-blender/files/5110554/zelda_ironknack.zip)) produces an `IndexError: index out of range` when trying to import. With my changes applied, it imports correctly with no errors.